### PR TITLE
Kick player immediately after max strikes have been exceeded

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -144,6 +144,8 @@ function PositionDeltaService:_exceededMaxMagnitude(player: Player?)
         if _configuration.DebugMode then
             warn(`{player.Name} has exceeded MaxMagnitude, strike {playerEntry.Strikes}`)
         end
+
+        if playerEntry.Strikes >= _configuration.MaxStrikes then PositionDeltaService:_handlePlayer(player, playerEntry) end
     end
 end
 
@@ -194,23 +196,28 @@ end
 
 -- Check player Strikes
 function PositionDeltaService:_handleStrikes()
-    -- filter through all player entries
-    for player: Player, entry: PlayerEntry in _playerData do
-        -- if player exceeded, kick them, otherwise reset strikes
-        if entry.Strikes >= _configuration.MaxStrikes then
-            -- Assess debug status
-            if _configuration.DebugMode then
-                warn(`{player.Name} has exceeded MaxStrikes`)
-                entry.Strikes = 0
+	-- filter through all player entries
+	for player: Player, entry: PlayerEntry in _playerData do
+		PositionDeltaService:_handlePlayer(player, entry)
+	end
+end
 
-                continue
-            end
+-- Check player strikes
+function PositionDeltaService:_handlePlayer(player: Player, entry: PlayerEntry)
+	-- if player exceeded, kick them, otherwise reset strikes
+	if entry.Strikes >= _configuration.MaxStrikes then
+		-- Assess debug status
+		if _configuration.DebugMode then
+			warn(`{player.Name} has exceeded MaxStrikes`)
+			entry.Strikes = 0
 
-            player:Kick()
-        else
-            entry.Strikes = 0
-        end
-    end
+			return
+		end
+
+		player:Kick()
+	else
+		entry.Strikes = 0
+	end
 end
 
 -- Update configuration

--- a/wally.toml
+++ b/wally.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lfg-studio/positiondeltaservice"
-version = "0.1.6"
+version = "0.2.0"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
 


### PR DESCRIPTION
Wanted to apply this patch as timing is essential for the removal of exploiters in a scenario where they're collecting items or triggering events that may be essential to gameplay. 

In the use case for Find the Blippis, this is specifically required to prevent exploiters from accessing UGC after meeting all blippi collection requirements (which we'd prevent them from doing effectively with this patch).