### PR TITLE
Variable detection axes & kicked signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Use the exported type `Configuration` to create a config and `PositionDeltaServi
 - StrikeDebounce: number | Seconds per strike allowance (prevents spamming)
 - StrikeRate: number | Seconds per MaxStrike check - Strikes reset each interval
 - MaxStrikes: number | Maximum strike allowance
+- Axes: Vector3 | Unit vector that defines axes to be considered for magnitude checks (good for only checking x,z movement)
 - DebugMode: boolean | Disables kicking, enables warns (helpful for determining best Configuration)
 
 ### **Configuration Example**
@@ -32,6 +33,7 @@ local configuration = {
     StrikeDebounce = 1,
     StrikeRate = 10,
     MaxStrikes = 5,
+    Axes = Vector3.new(1,1,1),
 
     DebugMode = true
 } :: PositionDeltaService.Configuration

--- a/src/init.lua
+++ b/src/init.lua
@@ -12,6 +12,7 @@ export type Configuration = {
     StrikeDebounce: number,
     StrikeRate: number,
     MaxStrikes: number,
+    Axes: Vector3,
 
     DebugMode: boolean
 }
@@ -34,6 +35,7 @@ local _configuration = {
     StrikeDebounce = 1,
     StrikeRate = 10,
     MaxStrikes = 5,
+    Axes = Vector3.new(1,1,1),
 
     DebugMode = false
 } :: Configuration
@@ -84,7 +86,7 @@ function PositionDeltaService:_playerAdded(player: Player?)
         _respawnConnections[player] = player.CharacterAdded:Connect(function(newCharacter: Model)
             -- zero out position entry to prevent false positive
             playerEntry.Position = Vector3.zero
-    
+
             -- listen for humanoid
             local humanoid = newCharacter:WaitForChild("Humanoid", 5) :: Humanoid?
             if humanoid then
@@ -173,7 +175,7 @@ function PositionDeltaService:_scan()
                 end
 
                 -- check magnitude
-                local currentPosition = character:GetPivot().Position
+                local currentPosition = character:GetPivot().Position * _configuration.Axes
                 local magnitude = (currentPosition - entry.Position).Magnitude
 
                 -- check to see if defined threshold was exceeded
@@ -190,7 +192,7 @@ function PositionDeltaService:_scan()
                 end
             end
         end)
-        
+
     end
 end
 
@@ -248,7 +250,7 @@ function PositionDeltaService:UpdateConfiguration(config: Configuration?)
             end
        end
     end
-    
+
     -- overwrite default configuration key by key in the event any keys weren't supplied
     for key, value in config do
         _configuration[key] = value
@@ -283,7 +285,7 @@ function PositionDeltaService:ToggleScan(player: Player?, scanActive: boolean)
     if scanActive then
         playerEntry.Position = Vector3.zero
     end
-    
+
     -- toggle ignore
     playerEntry.ScanActive = scanActive
 end
@@ -306,7 +308,7 @@ RunService.Heartbeat:Connect(function(deltaTime: number)
     -- add time passed
     magnitudeTimer += deltaTime
     strikeTimer += deltaTime
-        
+
     -- determine if it's time for a scan
     if magnitudeTimer >= _configuration.MagnitudeRate then
         magnitudeTimer = 0

--- a/src/init.lua
+++ b/src/init.lua
@@ -44,6 +44,8 @@ local _playerData = {} :: {[Player]: PlayerEntry}
 local _respawnConnections = {} :: {[Player]: RBXScriptConnection}
 local _diedConnections = {} :: {[Player]: RBXScriptConnection}
 
+local KickedEvent: BindableEvent = Instance.new("BindableEvent")
+
 -- Refs
 local magnitudeTimer = 0
 local strikeTimer = 0
@@ -51,7 +53,7 @@ local strikeTimer = 0
 
 
 -- Class
-local PositionDeltaService = {}
+local PositionDeltaService = {Kicked = KickedEvent.Event}
 
 -- Prevent client usage
 if not RunService:IsServer() then
@@ -192,7 +194,6 @@ function PositionDeltaService:_scan()
                 end
             end
         end)
-
     end
 end
 

--- a/src/init.lua
+++ b/src/init.lua
@@ -218,6 +218,7 @@ function PositionDeltaService:_handlePlayer(player: Player, entry: PlayerEntry)
 		end
 
 		player:Kick()
+        KickedEvent:Fire(player)
 	else
 		entry.Strikes = 0
 	end

--- a/wally.toml
+++ b/wally.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lfg-studio/positiondeltaservice"
-version = "0.2.0"
+version = "0.3.0"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
 


### PR DESCRIPTION
This patch introduces variable axes to consider in the exploit detection. The configurable unit vector can be used to reduce the sensitivity for or entirely nullify any of the x, y or z axes. In our use case for Find the Blippis, this prevents large, fast player drops from triggering the anti-exploit which may be due to reasons beyond a legitimate player's control like dropping after travelling far into the sky via jetpack. This is all whilst keeping the configuration set to sensitive settings.

This update also includes a signal that can be hooked for when a player is kicked from the game. In future, we can potentially add a bindable for strikes which could be useful for post-detection actions as well as any frontend feedback to the player.
